### PR TITLE
fix: No such file or directory: '/github/workspace/dist'

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -45,6 +45,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: statelint-build
+          path: dist
       - name: Publish distribution 📦 to Test PyPI
         uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
         if: ${{ github.event.release.prerelease && !github.event.release.draft }}


### PR DESCRIPTION
https://github.com/taro-kayo/statelint/actions/runs/14681908589/job/41205623286

```
Traceback (most recent call last):
  File "/app/print-pkg-names.py", line 30, in <module>
    pkg_name for file_path in packages_dir.iterdir() if
                              ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/pathlib.py", line 1056, in iterdir
    for name in os.listdir(self):
                ^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/github/workspace/dist'
```